### PR TITLE
TEPC actor example

### DIFF
--- a/dosimetry/TEPCActor/TEPCactor.pdf
+++ b/dosimetry/TEPCActor/TEPCactor.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd8ff3df83315821f436eef06f6b6427b3ddb67ed1276ccd2ac0bb54ad63bd21
+size 1024686

--- a/dosimetry/TEPCActor/data/myGateMaterials.db
+++ b/dosimetry/TEPCActor/data/myGateMaterials.db
@@ -1,0 +1,509 @@
+[Elements]
+Hydrogen:   S= H   ; Z=  1. ; A=   1.01  g/mole  
+Helium:     S= He  ; Z=  2. ; A=   4.003 g/mole
+Lithium:    S= Li  ; Z=  3. ; A=   6.941 g/mole
+Beryllium:  S= Be  ; Z=  4. ; A=   9.012 g/mole
+Boron:      S= B   ; Z=  5. ; A=  10.811 g/mole
+Carbon:     S= C   ; Z=  6. ; A=  12.01  g/mole
+Nitrogen:   S= N   ; Z=  7. ; A=  14.01  g/mole
+Oxygen:     S= O   ; Z=  8. ; A=  16.00  g/mole
+Fluorine:   S= F   ; Z=  9. ; A=  18.998 g/mole
+Neon:       S= Ne  ; Z= 10. ; A=  20.180 g/mole
+Sodium:     S= Na  ; Z= 11. ; A=  22.99  g/mole
+Magnesium:  S= Mg  ; Z= 12. ; A=  24.305 g/mole
+Aluminium:  S= Al  ; Z= 13. ; A=  26.98  g/mole
+Silicon:    S= Si  ; Z= 14. ; A=  28.09  g/mole
+Phosphor:   S= P   ; Z= 15. ; A=  30.97  g/mole
+Sulfur:     S= S   ; Z= 16. ; A=  32.066 g/mole
+Chlorine:   S= Cl  ; Z= 17. ; A=  35.45  g/mole
+Argon:	    S= Ar  ; Z= 18. ; A=  39.95  g/mole
+Potassium:  S= K   ; Z= 19. ; A=  39.098 g/mole
+Calcium:    S= Ca  ; Z= 20. ; A=  40.08	 g/mole
+Scandium:   S= Sc  ; Z= 21. ; A=  44.956 g/mole
+Titanium:   S= Ti  ; Z= 22. ; A=  47.867 g/mole
+Vandium:    S= V   ; Z= 23. ; A=  50.942 g/mole
+Chromium:   S= Cr  ; Z= 24. ; A=  51.996 g/mole
+Manganese:  S= Mn  ; Z= 25. ; A=  54.938 g/mole
+Iron:       S= Fe  ; Z= 26. ; A=  55.845 g/mole
+Cobalt:     S= Co  ; Z= 27. ; A=  58.933 g/mole
+Nickel:     S= Ni  ; Z= 28. ; A=  58.693 g/mole
+Copper:     S= Cu  ; Z= 29. ; A=  63.39  g/mole
+Zinc:       S= Zn  ; Z= 30. ; A=  65.39  g/mole
+Gallium:    S= Ga  ; Z= 31. ; A=  69.723 g/mole
+Germanium:  S= Ge  ; Z= 32. ; A=  72.61  g/mole
+Yttrium:    S= Y   ; Z= 39. ; A=  88.91  g/mole
+Silver:     S= Ag  ; Z= 47. ; A= 107.868 g/mole
+Cadmium:    S= Cd  ; Z= 48. ; A= 112.41  g/mole
+Tin:        S= Sn  ; Z= 50. ; A= 118.71  g/mole
+Tellurium:  S= Te  ; Z= 52. ; A= 127.6   g/mole
+Iodine:	    S= I   ; Z= 53. ; A= 126.90  g/mole
+Cesium:     S= Cs  ; Z= 55. ; A= 132.905 g/mole
+Gadolinium: S= Gd  ; Z= 64. ; A= 157.25  g/mole
+Lutetium:   S= Lu  ; Z= 71. ; A= 174.97  g/mole
+Tungsten:   S= W   ; Z= 74. ; A= 183.84  g/mole
+Gold:       S= Au  ; Z= 79. ; A= 196.967 g/mole
+Thallium:   S= Tl  ; Z= 81. ; A= 204.37  g/mole
+Lead: 	    S= Pb  ; Z= 82. ; A= 207.20  g/mole
+Bismuth:    S= Bi  ; Z= 83. ; A= 208.98  g/mole
+Uranium:    S= U   ; Z= 92. ; A= 238.03  g/mole
+
+[Materials]
+Vacuum: d=0.000001 mg/cm3 ; n=1 
+	+el: name=Hydrogen ; n=1
+
+Iodine: d=4.93 g/cm3 ; n=1
+	+el: name=auto; n=1
+
+Aluminium: d=2.7 g/cm3 ; n=1 ; state=solid
+	+el: name=auto ; n=1
+
+TE_A_150: d=1.127 g/cm3 ; n=6
+	+el: name=Hydrogen ; f=0.101
+	+el: name=Carbon   ; f=0.776
+	+el: name=Nitrogen ; f=0.035
+	+el: name=Oxygen   ; f=0.052
+	+el: name=Fluorine ; f=0.017
+	+el: name=Calcium  ; f=0.019
+
+TE_gas: d=0.00182628 g/cm3 ; n=4 ; state=gas
+	+el: name=Hydrogen ; f=0.10268
+	+el: name=Carbon   ; f=0.56893
+	+el: name=Nitrogen ; f=0.03503
+	+el: name=Oxygen   ; f=0.29336
+
+TE_gas_44mbar: d=0.07931 mg/cm3 ; n=4 ; state=gas
+	+el: name=Hydrogen ; f=0.10268
+	+el: name=Carbon   ; f=0.56893
+	+el: name=Nitrogen ; f=0.03503
+	+el: name=Oxygen   ; f=0.29336
+
+AluminiumEGS: d=2.702 g/cm3 ; n=1 ; state=solid
+         +el: name=Aluminium ; n=1
+
+Uranium: d=18.90 g/cm3 ; n=1 ; state=solid
+	+el: name=auto ; n=1
+
+Silicon: d=2.33 g/cm3 ; n=1 ; state=solid
+	+el: name=auto ; n=1
+
+Germanium: d=5.32 g/cm3 ; n=1 ; state=solid
+	+el: name=auto ; n=1
+
+Yttrium: d=4.47 g/cm3 ; n=1
+	+el: name=auto ; n=1
+
+Gadolinium: d=7.9 g/cm3 ; n=1
+	+el: name=auto ; n=1
+
+Lutetium: d=9.84 g/cm3 ; n=1
+	+el: name=auto ; n=1
+
+Tungsten: d=19.3 g/cm3 ; n=1 ; state=solid
+	+el: name=auto ; n=1
+
+Lead: d=11.4 g/cm3 ; n=1 ; state=solid
+	+el: name=auto ; n=1
+
+Bismuth: d=9.75 g/cm3 ; n=1 ; state=solid
+	+el: name=auto ; n=1
+
+NaI: d=3.67 g/cm3; n=2;  state=solid
+	+el: name=Sodium ; n=1
+  	+el: name=Iodine ; n=1
+
+PWO: d=8.28 g/cm3; n=3 ; state=Solid
+	+el: name=Lead; n=1
+  	+el: name=Tungsten; n=1
+  	+el: name=Oxygen; n=4
+
+BGO: d=7.13 g/cm3; n= 3 ; state=solid
+	+el: name=Bismuth; n=4
+	+el: name=Germanium; n=3
+	+el: name=Oxygen; n=12
+
+LSO: d=7.4 g/cm3; n=3 ; state=Solid
+	+el: name=Lutetium ; n=2
+	+el: name=Silicon; n=1
+	+el: name=Oxygen; n=5
+
+Plexiglass: d=1.19 g/cm3; n=3; state=solid
+        +el: name=Hydrogen;   f=0.080538
+        +el: name=Carbon;     f=0.599848
+        +el: name=Oxygen;     f=0.319614
+
+GSO: d=6.7 g/cm3; n=3 ; state=Solid
+	+el: name=Gadolinium ; n=2
+	+el: name=Silicon; n=1
+	+el: name=Oxygen; n=5
+
+LuAP: d=8.34 g/cm3; n=3 ; state=Solid
+	+el: name=Lutetium ; n=1
+	+el: name=Aluminium; n=1
+	+el: name=Oxygen; n=3
+
+YAP: d=5.55 g/cm3; n=3 ; state=Solid
+	+el: name=Yttrium ; n=1
+	+el: name=Aluminium; n=1
+	+el: name=Oxygen; n=3
+
+Water: d=1.00 g/cm3; n=2 ; state=liquid
+	+el: name=Hydrogen ; n=2
+	+el: name=Oxygen; n=1
+
+Quartz: d=2.2 g/cm3; n=2 ; state=Solid
+	+el: name=Silicon ; n=1
+	+el: name=Oxygen  ; n=2
+
+Breast: d=1.020 g/cm3 ; n = 8
+	+el: name=Oxygen;     f=0.5270
+	+el: name=Carbon;     f=0.3320
+	+el: name=Hydrogen ;  f=0.1060
+	+el: name=Nitrogen;   f=0.0300
+	+el: name=Sulfur ;    f=0.0020
+	+el: name=Sodium ;    f=0.0010
+	+el: name=Phosphor;   f=0.0010
+	+el: name=Chlorine ;  f=0.0010
+
+Air: d=1.29 mg/cm3 ; n=4 ; state=gas
+	+el: name=Nitrogen;   f=0.755268
+	+el: name=Oxygen;     f=0.231781
+	+el: name=Argon;      f=0.012827
+	+el: name=Carbon;     f=0.000124
+
+Glass: d=2.5 g/cm3; n=4;  state=solid
+	+el: name=Sodium ;    f=0.1020
+	+el: name=Calcium;    f=0.0510
+	+el: name=Silicon;    f=0.2480
+	+el: name=Oxygen;     f=0.5990
+
+Scinti-C9H10: d=1.032 g/cm3 ; n=2
+      	+el: name=Carbon;    n=9
+	+el: name=Hydrogen;  n=10
+
+LuYAP-70: d=7.1 g/cm3 ; n=4
+	+el: name=Lutetium ; n= 7
+	+el: name=Yttrium ;  n= 3
+	+el: name=Aluminium; n=10
+	+el: name=Oxygen;    n=30
+	
+LuYAP-80: d=7.5 g/cm3 ; n=4
+	+el: name=Lutetium ; n= 8
+	+el: name=Yttrium ;  n= 2
+	+el: name=Aluminium; n=10
+	+el: name=Oxygen;    n=30
+	
+Plastic:  d=1.18 g/cm3 ; n=3; state=solid
+        +el: name=Carbon ; n=5
+        +el: name=Hydrogen ; n=8
+        +el: name=Oxygen ; n=2
+
+Biomimic:  d=1.05 g/cm3 ; n=3; state=solid
+        +el: name=Carbon   ; n=5
+        +el: name=Hydrogen ; n=8
+        +el: name=Oxygen ; n=2
+
+FITC:  d=1.0 g/cm3 ; n=1
+        +el: name=Carbon   ; n=1
+
+RhB:  d=1.0 g/cm3 ; n=1
+        +el: name=Carbon   ; n=1
+
+CZT:  d=5.68 g/cm3 ; n=3; state=solid  
+        +el: name=Cadmium   ; n=9
+        +el: name=Zinc      ; n=1
+        +el: name=Tellurium ; n=10
+
+Lung:  d=0.26 g/cm3 ; n=9
+        +el: name=Hydrogen  ; f=0.103
+	+el: name=Carbon    ; f=0.105
+	+el: name=Nitrogen  ; f=0.031
+	+el: name=Oxygen    ; f=0.749
+	+el: name=Sodium    ; f=0.002
+	+el: name=Phosphor  ; f=0.002
+	+el: name=Sulfur    ; f=0.003
+        +el: name=Chlorine  ; f=0.003
+        +el: name=Potassium ; f=0.002
+
+Polyethylene:  d=0.96 g/cm3 ; n=2
+        +el: name=Hydrogen ; n=2
+        +el: name=Carbon   ; n=1
+
+PVC:  d=1.65 g/cm3 ; n=3 ;  state=solid
+        +el: name=Hydrogen ; n=3
+        +el: name=Carbon   ; n=2
+        +el: name=Chlorine ; n=1
+
+SS304:  d=7.92 g/cm3 ; n=4  ; state=solid
+        +el: name=Iron      ; f=0.695
+        +el: name=Chromium  ; f=0.190
+        +el: name=Nickel    ; f=0.095
+        +el: name=Manganese ; f=0.020
+
+PTFE:   d= 2.18 g/cm3 ; n=2 ; state=solid
+        +el: name=Carbon    ; n=1
+        +el: name=Fluorine  ; n=2
+
+
+LYSO:   d=5.37 g/cm3; n=4 ; state=Solid
+        +el: name=Lutetium ; f=0.31101534
+        +el: name=Yttrium ; f=0.368765605
+        +el: name=Silicon; f=0.083209699
+        +el: name=Oxygen; f=0.237009356
+
+Body:   d=1.00 g/cm3 ; n=2
+        +el: name=Hydrogen  ; f=0.112
+        +el: name=Oxygen    ; f=0.888
+                                                                                                                                         
+Muscle: d=1.05 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.102
+        +el: name=Carbon    ; f=0.143
+        +el: name=Nitrogen  ; f=0.034
+        +el: name=Oxygen    ; f=0.71
+        +el: name=Sodium    ; f=0.001
+        +el: name=Phosphor  ; f=0.002
+        +el: name=Sulfur    ; f=0.003
+        +el: name=Chlorine  ; f=0.001
+        +el: name=Potassium ; f=0.004
+        +el: name=Calcium   ; f=0.0
+        +el: name=Scandium  ; f=0.0
+                                                                                                                                            
+LungMoby: d=0.30 g/cm3 ; n=6
+        +el: name=Hydrogen  ; f=0.099
+        +el: name=Carbon    ; f=0.100
+        +el: name=Nitrogen  ; f=0.028
+        +el: name=Oxygen    ; f=0.740
+        +el: name=Phosphor  ; f=0.001
+        +el: name=Calcium   ; f=0.032
+                                                                                                                                       
+SpineBone: d=1.42 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.063
+        +el: name=Carbon    ; f=0.261
+        +el: name=Nitrogen  ; f=0.039
+        +el: name=Oxygen    ; f=0.436
+        +el: name=Sodium    ; f=0.001
+        +el: name=Magnesium ; f=0.001
+        +el: name=Phosphor  ; f=0.061
+        +el: name=Sulfur    ; f=0.003
+        +el: name=Chlorine  ; f=0.001
+        +el: name=Potassium ; f=0.001
+        +el: name=Calcium   ; f=0.133
+                                                                                                                                          
+RibBone: d=1.92 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.034
+        +el: name=Carbon    ; f=0.155
+        +el: name=Nitrogen  ; f=0.042
+        +el: name=Oxygen    ; f=0.435
+        +el: name=Sodium    ; f=0.001
+        +el: name=Magnesium ; f=0.002
+        +el: name=Phosphor  ; f=0.103
+        +el: name=Sulfur    ; f=0.003
+        +el: name=Calcium   ; f=0.225
+        +el: name=Scandium  ; f=0.0
+        +el: name=Titanium  ; f=0.0
+
+Adipose: d=0.92 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.120
+        +el: name=Carbon    ; f=0.640
+        +el: name=Nitrogen  ; f=0.008
+        +el: name=Oxygen    ; f=0.229
+        +el: name=Phosphor  ; f=0.002
+        +el: name=Calcium   ; f=0.001
+        +el: name=Scandium  ; f=0.0
+        +el: name=Titanium  ; f=0.0
+        +el: name=Vandium   ; f=0.0
+        +el: name=Chromium  ; f=0.0
+        +el: name=Manganese ; f=0.0
+
+Epidermis: d=0.92 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.120
+        +el: name=Carbon    ; f=0.640
+        +el: name=Nitrogen  ; f=0.008
+        +el: name=Oxygen    ; f=0.229
+        +el: name=Phosphor  ; f=0.002
+        +el: name=Calcium   ; f=0.001
+        +el: name=Scandium  ; f=0.0
+        +el: name=Titanium  ; f=0.0
+        +el: name=Vandium   ; f=0.0
+        +el: name=Chromium  ; f=0.0
+        +el: name=Manganese ; f=0.0
+
+Hypodermis: d=0.92 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.120
+        +el: name=Carbon    ; f=0.640
+        +el: name=Nitrogen  ; f=0.008
+        +el: name=Oxygen    ; f=0.229
+        +el: name=Phosphor  ; f=0.002
+        +el: name=Calcium   ; f=0.001
+        +el: name=Scandium  ; f=0.0
+        +el: name=Titanium  ; f=0.0
+        +el: name=Vandium   ; f=0.0
+        +el: name=Chromium  ; f=0.0
+        +el: name=Manganese ; f=0.0
+
+Blood:  d=1.06 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.102
+        +el: name=Carbon    ; f=0.11
+        +el: name=Nitrogen  ; f=0.033
+        +el: name=Oxygen    ; f=0.745
+        +el: name=Sodium    ; f=0.001
+        +el: name=Phosphor  ; f=0.001
+        +el: name=Sulfur    ; f=0.002
+        +el: name=Chlorine  ; f=0.003
+        +el: name=Potassium ; f=0.002
+        +el: name=Iron      ; f=0.001
+        +el: name=Cobalt    ; f=0.0
+
+Heart:  d=1.05 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.104
+        +el: name=Carbon    ; f=0.139
+        +el: name=Nitrogen  ; f=0.029
+        +el: name=Oxygen    ; f=0.718
+        +el: name=Sodium    ; f=0.001
+        +el: name=Phosphor  ; f=0.002
+        +el: name=Sulfur    ; f=0.002
+        +el: name=Chlorine  ; f=0.002
+        +el: name=Potassium ; f=0.003
+        +el: name=Calcium   ; f=0.0
+        +el: name=Scandium  ; f=0.0
+ 
+Kidney: d=1.05 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.103
+        +el: name=Carbon    ; f=0.132
+        +el: name=Nitrogen  ; f=0.03
+        +el: name=Oxygen    ; f=0.724
+        +el: name=Sodium    ; f=0.002
+        +el: name=Phosphor  ; f=0.002
+        +el: name=Sulfur    ; f=0.002
+        +el: name=Chlorine  ; f=0.002
+        +el: name=Potassium ; f=0.002
+        +el: name=Calcium   ; f=0.001
+        +el: name=Scandium  ; f=0.0
+ 
+Liver:  d=1.06 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.102
+        +el: name=Carbon    ; f=0.139
+        +el: name=Nitrogen  ; f=0.03
+        +el: name=Oxygen    ; f=0.716
+        +el: name=Sodium    ; f=0.002
+        +el: name=Phosphor  ; f=0.003
+        +el: name=Sulfur    ; f=0.003
+        +el: name=Chlorine  ; f=0.002
+        +el: name=Potassium ; f=0.003
+        +el: name=Calcium   ; f=0.0
+        +el: name=Scandium  ; f=0.0
+
+Lymph:  d=1.03 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.108
+        +el: name=Carbon    ; f=0.041
+        +el: name=Nitrogen  ; f=0.011
+        +el: name=Oxygen    ; f=0.832
+        +el: name=Sodium    ; f=0.003
+        +el: name=Sulfur    ; f=0.001
+        +el: name=Chlorine  ; f=0.004
+        +el: name=Argon     ; f=0.0
+        +el: name=Potassium ; f=0.0
+        +el: name=Calcium   ; f=0.0
+        +el: name=Scandium  ; f=0.0
+
+Pancreas: d=1.04 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.106
+        +el: name=Carbon    ; f=0.169
+        +el: name=Nitrogen  ; f=0.022
+        +el: name=Oxygen    ; f=0.694
+        +el: name=Sodium    ; f=0.002
+        +el: name=Phosphor  ; f=0.002
+        +el: name=Sulfur    ; f=0.001
+        +el: name=Chlorine  ; f=0.002
+        +el: name=Potassium ; f=0.002
+        +el: name=Calcium   ; f=0.0
+        +el: name=Scandium  ; f=0.0
+ 
+Intestine: d=1.03 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.106
+        +el: name=Carbon    ; f=0.115
+        +el: name=Nitrogen  ; f=0.022
+        +el: name=Oxygen    ; f=0.751
+        +el: name=Sodium    ; f=0.001
+        +el: name=Phosphor  ; f=0.001
+        +el: name=Sulfur    ; f=0.001
+        +el: name=Chlorine  ; f=0.002
+        +el: name=Potassium ; f=0.001
+        +el: name=Calcium   ; f=0.0
+        +el: name=Scandium  ; f=0.0
+ 
+Skull:  d=1.61 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.05
+        +el: name=Carbon    ; f=0.212
+        +el: name=Nitrogen  ; f=0.04
+        +el: name=Oxygen    ; f=0.435
+        +el: name=Sodium    ; f=0.001
+        +el: name=Magnesium ; f=0.002
+        +el: name=Phosphor  ; f=0.081
+        +el: name=Sulfur    ; f=0.003
+        +el: name=Calcium   ; f=0.176
+        +el: name=Scandium  ; f=0.0
+        +el: name=Titanium  ; f=0.0
+
+Cartilage: d=1.10 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.096
+        +el: name=Carbon    ; f=0.099
+        +el: name=Nitrogen  ; f=0.022
+        +el: name=Oxygen    ; f=0.744
+        +el: name=Sodium    ; f=0.005
+        +el: name=Phosphor  ; f=0.022
+        +el: name=Sulfur    ; f=0.009
+        +el: name=Chlorine  ; f=0.003
+        +el: name=Argon     ; f=0.0
+        +el: name=Potassium ; f=0.0
+        +el: name=Calcium   ; f=0.0
+ 
+Brain:  d=1.04 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.107
+        +el: name=Carbon    ; f=0.145
+        +el: name=Nitrogen  ; f=0.022
+        +el: name=Oxygen    ; f=0.712
+        +el: name=Sodium    ; f=0.002
+        +el: name=Phosphor  ; f=0.004
+        +el: name=Sulfur    ; f=0.002
+        +el: name=Chlorine  ; f=0.003
+        +el: name=Potassium ; f=0.003
+        +el: name=Calcium   ; f=0.0
+        +el: name=Scandium  ; f=0.0
+
+Spleen: d=1.06 g/cm3 ; n=11
+        +el: name=Hydrogen  ; f=0.103
+        +el: name=Carbon    ; f=0.113
+        +el: name=Nitrogen  ; f=0.032
+        +el: name=Oxygen    ; f=0.741
+        +el: name=Sodium    ; f=0.001
+        +el: name=Phosphor  ; f=0.003
+        +el: name=Sulfur    ; f=0.002
+        +el: name=Chlorine  ; f=0.002
+        +el: name=Potassium ; f=0.003
+        +el: name=Calcium   ; f=0.0
+        +el: name=Scandium  ; f=0.0
+
+Testis: d=1.04 g/cm3 ; n=9
+        +el: name=Hydrogen   ; f=0.106000
+        +el: name=Carbon     ; f=0.099000
+        +el: name=Nitrogen   ; f=0.020000
+        +el: name=Oxygen     ; f=0.766000
+        +el: name=Sodium     ; f=0.002000
+        +el: name=Phosphor   ; f=0.001000
+        +el: name=Sulfur     ; f=0.002000
+        +el: name=Chlorine   ; f=0.002000
+        +el: name=Potassium  ; f=0.002000
+
+PMMA:   d=1.195 g/cm3; n=3 ; state=Solid
+        +el: name=Hydrogen ; f=0.080541
+        +el: name=Carbon ; f=0.599846
+        +el: name=Oxygen; f=0.319613
+
+Epoxy:  d=1.0 g/cm3; n=3; state=Solid
+        +el: name=Carbon; n=1
+        +el: name=Hydrogen; n=1
+        +el: name=Oxygen; n=1
+
+Carbide: d=15.8 g/cm3; n=2 ; state=Solid
+        +el: name=Tungsten ; n=1
+        +el: name=Carbon ; n=1

--- a/dosimetry/TEPCActor/mac/main_optimizedTEPC.mac
+++ b/dosimetry/TEPCActor/mac/main_optimizedTEPC.mac
@@ -1,0 +1,191 @@
+#=====================================================
+# VERBOSE and VISUALISATION 
+#=====================================================
+
+/gate/verbose Physic    0
+/gate/verbose Cuts      0
+/gate/verbose SD        0
+/gate/verbose Actions   0
+/gate/verbose Actor     0
+/gate/verbose Step      0
+/gate/verbose Error     0
+/gate/verbose Warning   0
+/gate/verbose Output    0
+/gate/verbose Beam      0
+/gate/verbose Volume    0
+/gate/verbose Image     0
+/gate/verbose Geometry  0
+
+#/control/execute mac/visu.mac
+
+#=====================================================
+# GEOMETRY and ACTORS
+#=====================================================
+
+/gate/geometry/setMaterialDatabase data/myGateMaterials.db
+
+# -----------------------------------------------------
+# Water box
+
+/gate/world/setMaterial         Vacuum
+/gate/world/geometry/setXLength 2 m
+/gate/world/geometry/setYLength 2 m
+/gate/world/geometry/setZLength 2 m
+
+/gate/world/daughters/name     tank
+/gate/world/daughters/insert   box
+/gate/tank/setMaterial         Water
+/gate/tank/geometry/setXLength 300 mm
+/gate/tank/geometry/setYLength 300 mm
+/gate/tank/geometry/setZLength 300 mm
+/gate/tank/vis/setColor green
+/gate/tank/vis/forceWireframe
+
+# -----------------------------------------------------
+# TEPC geometry
+
+/gate/tank/daughters/name       TEPC
+/gate/tank/daughters/insert     sphere
+/gate/TEPC/geometry/setRmin     0.0 mm
+/gate/TEPC/geometry/setRmax     7.62 mm
+/gate/TEPC/setMaterial          TE_A_150
+/gate/TEPC/vis/setColor         white
+
+# measurement_position = - halfZ_tank(150.00mm) + radius_TEPCgas(6.35mm) + depth
+# ---- TEPC in the plateau region (depth=50mm)
+/gate/TEPC/placement/setTranslation  0.0 0.0 -93.65 mm
+# ---- TEPC in the peak region (depth=160mm)
+#/gate/TEPC/placement/setTranslation  0.0 0.0 16.35 mm
+
+/gate/TEPC/daughters/name       TEPCcut1
+/gate/TEPC/daughters/insert     sphere
+/gate/TEPCcut1/geometry/setRmin 6.361 mm
+/gate/TEPCcut1/geometry/setRmax 6.461 mm
+/gate/TEPCcut1/setMaterial      TE_A_150
+/gate/TEPCcut1/placement/setTranslation  0.0 0.0 0.0 mm
+/gate/TEPCcut1/vis/setColor     white
+
+/gate/TEPC/daughters/name       TEPCcut2
+/gate/TEPC/daughters/insert     sphere
+/gate/TEPCcut2/geometry/setRmin 6.351 mm
+/gate/TEPCcut2/geometry/setRmax 6.361 mm
+/gate/TEPCcut2/setMaterial      TE_A_150
+/gate/TEPCcut2/placement/setTranslation  0.0 0.0 0.0 mm
+/gate/TEPCcut2/vis/setColor     white
+
+/gate/TEPC/daughters/name       TEPCcut3
+/gate/TEPC/daughters/insert     sphere
+/gate/TEPCcut3/geometry/setRmin 6.350 mm
+/gate/TEPCcut3/geometry/setRmax 6.351 mm
+/gate/TEPCcut3/setMaterial      TE_A_150
+/gate/TEPCcut3/placement/setTranslation  0.0 0.0 0.0 mm
+/gate/TEPCcut3/vis/setColor     white
+
+/gate/TEPC/daughters/name       TEPCgas
+/gate/TEPC/daughters/insert     sphere
+/gate/TEPCgas/geometry/setRmin  0.0 mm
+/gate/TEPCgas/geometry/setRmax  6.35 mm
+/gate/TEPCgas/setMaterial       TE_gas
+/gate/TEPCgas/placement/setTranslation 0.0 0.0 0.0 mm
+/gate/TEPCgas/vis/setColor      blue
+/gate/TEPCgas/vis/forceSolid
+
+#=====================================================
+# ACTOR
+#=====================================================
+
+/gate/actor/addActor               SimulationStatisticActor stat
+/gate/actor/stat/save              output/stat.txt
+/gate/actor/stat/saveEveryNSeconds 60
+
+/gate/actor/addActor     TEPCActor myTEPC
+/gate/actor/myTEPC/attachTo        TEPCgas
+/gate/actor/myTEPC/save            output/myLETspectrum.root
+/gate/actor/myTEPC/saveAsText      false
+/gate/actor/myTEPC/setPressure     0.044 bar
+/gate/actor/myTEPC/setLogscale     true
+/gate/actor/myTEPC/setNumberOfBins 150
+/gate/actor/myTEPC/setEmin         0.01 keV
+/gate/actor/myTEPC/setNOrders      6
+/gate/actor/myTEPC/setNormByEvent  true
+
+#=====================================================
+# PHYSIC
+#=====================================================
+
+/gate/physics/addPhysicsList QGSP_BIC_HP_PEN
+
+#=====================================================
+# CUTS
+#=====================================================
+
+/gate/physics/Gamma/SetCutInRegion      tank 1 mm
+/gate/physics/Electron/SetCutInRegion   tank 1 mm
+/gate/physics/Positron/SetCutInRegion   tank 1 mm
+/gate/physics/Proton/SetCutInRegion     tank 1 mm
+
+/gate/physics/Gamma/SetCutInRegion      TEPC 0.1 mm
+/gate/physics/Electron/SetCutInRegion   TEPC 0.1 mm
+/gate/physics/Positron/SetCutInRegion   TEPC 0.1 mm
+/gate/physics/Proton/SetCutInRegion     TEPC 0.1 mm
+
+/gate/physics/Gamma/SetCutInRegion      TEPCcut1 0.01 mm
+/gate/physics/Electron/SetCutInRegion   TEPCcut1 0.01 mm
+/gate/physics/Positron/SetCutInRegion   TEPCcut1 0.01 mm
+/gate/physics/Proton/SetCutInRegion     TEPCcut1 0.01 mm
+
+/gate/physics/Gamma/SetCutInRegion      TEPCcut2 0.001 mm
+/gate/physics/Electron/SetCutInRegion   TEPCcut2 0.001 mm
+/gate/physics/Positron/SetCutInRegion   TEPCcut2 0.001 mm
+/gate/physics/Proton/SetCutInRegion     TEPCcut2 0.001 mm
+
+/gate/physics/Gamma/SetCutInRegion      TEPCcut3 0.0001 mm
+/gate/physics/Electron/SetCutInRegion   TEPCcut3 0.0001 mm
+/gate/physics/Positron/SetCutInRegion   TEPCcut3 0.0001 mm
+/gate/physics/Proton/SetCutInRegion     TEPCcut3 0.0001 mm
+
+/gate/physics/Gamma/SetCutInRegion      TEPCgas 0.0001 mm
+/gate/physics/Electron/SetCutInRegion   TEPCgas 0.0001 mm
+/gate/physics/Positron/SetCutInRegion   TEPCgas 0.0001 mm
+/gate/physics/Proton/SetCutInRegion     TEPCgas 0.0001 mm
+
+#------------
+# stepLimiter
+#------------
+
+/gate/physics/SetMaxStepSizeInRegion    tank     1.0 mm
+/gate/physics/SetMaxStepSizeInRegion    TEPC     0.1 mm
+/gate/physics/SetMaxStepSizeInRegion    TEPCcut1 0.01 mm
+/gate/physics/SetMaxStepSizeInRegion    TEPCcut2 0.001 mm
+/gate/physics/SetMaxStepSizeInRegion    TEPCcut3 0.0001 mm
+/gate/physics/SetMaxStepSizeInRegion    TEPCgas  1.0 mm
+
+/gate/physics/ActivateStepLimiter proton
+
+/gate/physics/displayCuts
+
+#=====================================================
+# BEAM
+#=====================================================
+
+/gate/source/addSource              protongun   gps
+/gate/source/protongun/gps/particle   proton
+/gate/source/protongun/gps/monoenergy 155 MeV 
+/gate/source/protongun/gps/type       Plane
+/gate/source/protongun/gps/pos/shape  Circle
+/gate/source/protongun/gps/pos/radius 25.0 mm 
+/gate/source/protongun/gps/centre     0.0 0.0 -400.0 mm 
+/gate/source/protongun/gps/direction  0 0 1      
+
+#=====================================================
+# MAIN
+#=====================================================
+
+/gate/random/setEngineName MersenneTwister
+/gate/random/setEngineSeed auto
+/gate/run/enableGlobalOutput true
+/gate/run/initialize
+
+# PARTICLE
+/gate/application/setTotalNumberOfPrimaries 1000000
+/gate/application/start

--- a/dosimetry/TEPCActor/mac/visu.mac
+++ b/dosimetry/TEPCActor/mac/visu.mac
@@ -1,0 +1,16 @@
+/vis/open OGLSX 1000
+/vis/drawVolume
+/vis/viewer/flush
+/tracking/storeTrajectory 1
+/vis/scene/add/trajectories
+#/vis/scene/endOfEventAction accumulate 1
+
+/vis/scene/add/axes            -150 300 100 100 mm
+#/vis/viewer/set/auxiliaryEdge true
+
+/vis/viewer/set/viewpointThetaPhi  60 40
+/vis/viewer/zoom 4
+
+
+
+

--- a/dosimetry/TEPCActor/output/results.txt
+++ b/dosimetry/TEPCActor/output/results.txt
@@ -1,0 +1,1 @@
+put your results here !

--- a/dosimetry/TEPCActor/readme.txt
+++ b/dosimetry/TEPCActor/readme.txt
@@ -1,0 +1,34 @@
+=======================================
+        GATE - TEPC actor
+=======================================
+
+Authors:  F. Smekens, L. Maigne*
+Laboratoire de Physique de Clermont, UMR6533 University Clermont Auvergne CNRS/IN2P3 - France
+* Corresponding author: lydia.maigne@clermont.in2p3.fr
+
+
+---> Description
+
+This example shows how to use the TEPC actor in order to register the lineal energy transfer (LET) distribution using a TEPC detector geometry.
+This detector has the specificity to mimic the shape and composition of structures (about 1 um of diameter) sensitive to radiation in a cell nucleus.
+The final LET distribution is generally used to calculate the biological dose for high LET radiation or to characterize the beam quality for radioprotection issues.
+
+---> Set-up
+
+The geometry consists in a spherical TEPC detector positioned in a water tank. The TEPC is composed of a wall of A-150 plastic of 1.27 mm width and a low pressure tissue-equivalent gas cavity of 12.7 mm radius.
+This geometry is irradiated with a circular (radius of 25 mm) monoenergetic 155 MeV proton beam.
+The TEPC detector can be positioned at two different depths along the Bragg dose profile in order to measure the LET distribution: (1) the plateau region at 50 mm and (2) the peak region at 160 mm.
+
+---> Physics and cuts
+
+The QGSP_BIC_HP physicsList is set up following the recommendations concerning medical applications using protons. 
+In order to optimize the computing time, the TEPC wall is subdivided into 5 regions where cuts and stepLimiters decrease from the outer to the inner region.
+
+---> Output
+
+The LET distribution is scored using a TEPC actor. Users have the possibility to set the energy range of the final distribution and to plot it using linear or logarithm scales. User can also tune the low pressure gas in the TEPC cavity. The final output is saved as a Root file. In order to observe the plots, the ROOT viewer will have to be set with the 'setLogX' and 'setLogY' options activated.
+
+Note: a detailed description of the commands available for the TEPC actor can be found on the Gate/Geant4 wiki. The optimization of the cuts and stepLimiters for this TEPC geometry is also described.  
+
+=======================================
+


### PR DESCRIPTION
- optimized tissue-equivalent proportional counter (TEPC) geometry
- stores the LET distribution at the TEPC position