### PR TITLE
Split Exponential doc

### DIFF
--- a/dosimetry/Radiotherapy/example10/seTLE.pdf
+++ b/dosimetry/Radiotherapy/example10/seTLE.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97c647b9bb82123b0c7f3d445dfd4facf5982572c87d346ff92fd3f02f82c581
+size 593374


### PR DESCRIPTION
The Gate documentation points to a dead link, http://midas3.kitware.com/midas/download/item/316877/seTLE.pdf. I think it's the file I'm committing with this PR and I suggest to add it here (with git-lfs if I did things correctly). Can someone check?
There is another file missing https://midas3.kitware.com/midas/download/item/321835/Davis_LUTs.tar.gz if anyone has kept a copy, we can add them in a similar fashion.
Simon