### PR TITLE
Update submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,3 @@
 [submodule "imaging/garf/mac/nm670"]
 	path = imaging/garf/mac/nm670
-	url = git@gitlab.in2p3.fr:davidsarrut/gate_mac_nm670.git
-[submodule "imaging/garf/nm670"]
-	path = imaging/garf/nm670
-	url = git@gitlab.in2p3.fr:davidsarrut/gate_mac_nm670.git
-[submodule "imaging/garf/--name"]
-	path = imaging/garf/--name
-	url = git@gitlab.in2p3.fr:davidsarrut/gate_mac_nm670.git
-[submodule "imaging/garf/data/nm670"]
-	path = imaging/garf/data/nm670
-	url = git@gitlab.in2p3.fr:davidsarrut/gate_mac_nm670.git
+	url = https://gitlab.in2p3.fr/davidsarrut/gate_mac_nm670.git


### PR DESCRIPTION
Change url to gate_mac_nm670 from git address to https address. The git address is available only for people who upload their ssh-key on the in2p3 gitlab.
Remove old nm670 submodule repository