### PR TITLE
 fix visualization for optical system

### DIFF
--- a/imaging/LUTDavisModel/Optical_System.mac
+++ b/imaging/LUTDavisModel/Optical_System.mac
@@ -25,13 +25,6 @@
 #-------------------oooooOOOOO00000OOOOOooooo---------------------#
 
 
-#=====================================================
-# VISUALISATION and VERBOSE
-#=====================================================
-
-##/vis/disable
-/control/execute                    ./macro/Visualisation.mac
-/control/execute                    ./macro/Verbose.mac
 
 #=====================================================
 # GEOMETRY
@@ -92,6 +85,13 @@
 
 /gate/run/initialize
 
+#=====================================================
+# VISUALISATION and VERBOSE
+#=====================================================
+
+##/vis/disable
+/control/execute                    ./macro/Visualisation.mac
+/control/execute                    ./macro/Verbose.mac
 
 #===============================================================
 # Optical photons Detection Surface should be DIELECTRIC-METAL

--- a/imaging/Optical/Optical_System.mac
+++ b/imaging/Optical/Optical_System.mac
@@ -25,13 +25,6 @@
 #-------------------oooooOOOOO00000OOOOOooooo---------------------#
 
 
-#=====================================================
-# VISUALISATION and VERBOSE
-#=====================================================
-
-#/vis/disable
-#/control/execute                    ./macro/Visualisation.mac
-/control/execute                    ./macro/Verbose.mac
 
 #=====================================================
 # GEOMETRY
@@ -106,6 +99,13 @@
 
 /gate/run/initialize
 
+#=====================================================
+# VISUALISATION and VERBOSE
+#=====================================================
+
+#/vis/disable
+#/control/execute                    ./macro/Visualisation.mac
+/control/execute                    ./macro/Verbose.mac
 
 #=====================================================
 # SURFACES


### PR DESCRIPTION
put viusalisation after initialization to avoid an uncomfortable exception:

-------- WWWW ------- G4Exception-START -------- WWWW -------  
*** G4Exception : modeling0015                                                            
      issued by : G4PhysicalVolumeModel::Validate                                  
Attempt to validate a volume that is no longer in the physical volume store.  
*** This is just a warning message. ***                                                       
-------- WWWW -------- G4Exception-END --------- WWWW -------

